### PR TITLE
feat: build only on pushes to master

### DIFF
--- a/.github/workflows/algorithms-cpp.yml
+++ b/.github/workflows/algorithms-cpp.yml
@@ -1,6 +1,9 @@
-name: CMake
+name: algorithms-cpp
 
-on: [push]
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   build:


### PR DESCRIPTION
Now that local dev runs in exactly the same environment as
that in the ci workflow, run workflow only on pushes to master
to save on minutes of compute.